### PR TITLE
Recolor support for editor category buttons

### DIFF
--- a/HUDReplacer.cs
+++ b/HUDReplacer.cs
@@ -718,7 +718,105 @@ namespace HUDReplacer
 						HarmonyPatches.RCSDisplayColor_RCS_Off_color = configFile.config.GetValue(RCSDisplayOffColor).ToRGBA();
 					}
 				}
+				
+				string EditorCategoryButtonColor = "EditorCategoryButtonColor";
+				if (configFile.config.HasValue(EditorCategoryButtonColor))
+				{
+					if (!colorsSet.Contains(EditorCategoryButtonColor))
+					{
+						colorsSet.Add(EditorCategoryButtonColor);
+						HarmonyPatches.EditorCategoryButtonColor_replace = true;
+						HarmonyPatches.EditorCategoryButtonColor_color = configFile.config.GetValue(EditorCategoryButtonColor).ToRGBA();
+					}
+				}
 
+				string EditorCategoryButtonColor_Module = "EditorCategoryModuleButtonColor";
+				if (configFile.config.HasValue(EditorCategoryButtonColor_Module))
+				{
+					if (!colorsSet.Contains(EditorCategoryButtonColor_Module))
+					{
+						colorsSet.Add(EditorCategoryButtonColor_Module);
+						HarmonyPatches.EditorCategoryButtonColor_Module_replace = true;
+						HarmonyPatches.EditorCategoryButtonColor_Module_color = configFile.config.GetValue(EditorCategoryButtonColor_Module).ToRGBA();
+					}
+				}
+
+				string EditorCategoryButtonColor_Resource = "EditorCategoryResourceButtonColor";
+				if (configFile.config.HasValue(EditorCategoryButtonColor_Resource))
+				{
+					if (!colorsSet.Contains(EditorCategoryButtonColor_Resource))
+					{
+						colorsSet.Add(EditorCategoryButtonColor_Resource);
+						HarmonyPatches.EditorCategoryButtonColor_Resource_replace = true;
+						HarmonyPatches.EditorCategoryButtonColor_Resource_color = configFile.config.GetValue(EditorCategoryButtonColor_Resource).ToRGBA();
+					}
+				}
+
+				string EditorCategoryButtonColor_Manufacturer = "EditorCategoryManufacturerButtonColor";
+				if (configFile.config.HasValue(EditorCategoryButtonColor_Manufacturer))
+				{
+					if (!colorsSet.Contains(EditorCategoryButtonColor_Manufacturer))
+					{
+						colorsSet.Add(EditorCategoryButtonColor_Manufacturer);
+						HarmonyPatches.EditorCategoryButtonColor_Manufacturer_replace = true;
+						HarmonyPatches.EditorCategoryButtonColor_Manufacturer_color = configFile.config.GetValue(EditorCategoryButtonColor_Manufacturer).ToRGBA();
+					}
+				}
+
+				string EditorCategoryButtonColor_Tech = "EditorCategoryTechButtonColor";
+				if (configFile.config.HasValue(EditorCategoryButtonColor_Tech))
+				{
+					if (!colorsSet.Contains(EditorCategoryButtonColor_Tech))
+					{
+						colorsSet.Add(EditorCategoryButtonColor_Tech);
+						HarmonyPatches.EditorCategoryButtonColor_Tech_replace = true;
+						HarmonyPatches.EditorCategoryButtonColor_Tech_color = configFile.config.GetValue(EditorCategoryButtonColor_Tech).ToRGBA();
+					}
+				}
+
+				string EditorCategoryButtonColor_Profile = "EditorCategoryProfileButtonColor";
+				if (configFile.config.HasValue(EditorCategoryButtonColor_Profile))
+				{
+					if (!colorsSet.Contains(EditorCategoryButtonColor_Profile))
+					{
+						colorsSet.Add(EditorCategoryButtonColor_Profile);
+						HarmonyPatches.EditorCategoryButtonColor_Profile_replace = true;
+						HarmonyPatches.EditorCategoryButtonColor_Profile_color = configFile.config.GetValue(EditorCategoryButtonColor_Profile).ToRGBA();
+					}
+				}
+
+				string EditorCategoryButtonColor_Subassembly = "EditorCategorySubassemblyButtonColor";
+				if (configFile.config.HasValue(EditorCategoryButtonColor_Subassembly))
+				{
+					if (!colorsSet.Contains(EditorCategoryButtonColor_Subassembly))
+					{
+						colorsSet.Add(EditorCategoryButtonColor_Subassembly);
+						HarmonyPatches.EditorCategoryButtonColor_Subassembly_replace = true;
+						HarmonyPatches.EditorCategoryButtonColor_Subassembly_color = configFile.config.GetValue(EditorCategoryButtonColor_Subassembly).ToRGBA();
+					}
+				}
+
+				string EditorCategoryButtonColor_Variants = "EditorCategoryVariantsButtonColor";
+				if (configFile.config.HasValue(EditorCategoryButtonColor_Variants))
+				{
+					if (!colorsSet.Contains(EditorCategoryButtonColor_Variants))
+					{
+						colorsSet.Add(EditorCategoryButtonColor_Variants);
+						HarmonyPatches.EditorCategoryButtonColor_Variants_replace = true;
+						HarmonyPatches.EditorCategoryButtonColor_Variants_color = configFile.config.GetValue(EditorCategoryButtonColor_Variants).ToRGBA();
+					}
+				}
+
+				string EditorCategoryButtonColor_Custom = "EditorCategoryCustomButtonColor";
+				if (configFile.config.HasValue(EditorCategoryButtonColor_Custom))
+				{
+					if (!colorsSet.Contains(EditorCategoryButtonColor_Custom))
+					{
+						colorsSet.Add(EditorCategoryButtonColor_Custom);
+						HarmonyPatches.EditorCategoryButtonColor_Custom_replace = true;
+						HarmonyPatches.EditorCategoryButtonColor_Custom_color = configFile.config.GetValue(EditorCategoryButtonColor_Custom).ToRGBA();
+					}
+				}
 			}
 		}
 		/*

--- a/HarmonyPatches.cs
+++ b/HarmonyPatches.cs
@@ -769,6 +769,68 @@ namespace HUDReplacer
 				}
 			}
 		}
+
+		internal static bool EditorCategoryButtonColor_replace = false;
+		internal static bool EditorCategoryButtonColor_Module_replace = false;
+		internal static bool EditorCategoryButtonColor_Resource_replace = false;
+		internal static bool EditorCategoryButtonColor_Manufacturer_replace = false;
+		internal static bool EditorCategoryButtonColor_Tech_replace = false;
+		internal static bool EditorCategoryButtonColor_Profile_replace = false;
+		internal static bool EditorCategoryButtonColor_Subassembly_replace = false;
+		internal static bool EditorCategoryButtonColor_Variants_replace = false;
+		internal static bool EditorCategoryButtonColor_Custom_replace = false;
+		internal static Color EditorCategoryButtonColor_color;
+		internal static Color EditorCategoryButtonColor_Module_color;
+		internal static Color EditorCategoryButtonColor_Resource_color;
+		internal static Color EditorCategoryButtonColor_Manufacturer_color;
+		internal static Color EditorCategoryButtonColor_Tech_color;
+		internal static Color EditorCategoryButtonColor_Profile_color;
+		internal static Color EditorCategoryButtonColor_Subassembly_color;
+		internal static Color EditorCategoryButtonColor_Variants_color;
+		internal static Color EditorCategoryButtonColor_Custom_color;
+
+		[HarmonyPatch(typeof(PartCategorizer), "Setup")]
+		class Patch17 {
+			static void Prefix(ref PartCategorizer __instance)
+			{
+				if (EditorCategoryButtonColor_replace)
+				{
+					__instance.colorFilterFunction = EditorCategoryButtonColor_color;
+				}
+				if (EditorCategoryButtonColor_Module_replace)
+				{
+					__instance.colorFilterModule = EditorCategoryButtonColor_Module_color;
+				}
+				if (EditorCategoryButtonColor_Resource_replace)
+				{
+					__instance.colorFilterResource = EditorCategoryButtonColor_Resource_color;
+				}
+				if (EditorCategoryButtonColor_Manufacturer_replace)
+				{
+					__instance.colorFilterManufacturer = EditorCategoryButtonColor_Manufacturer_color;
+				}
+				if (EditorCategoryButtonColor_Tech_replace)
+				{
+					__instance.colorFilterTech = EditorCategoryButtonColor_Tech_color;
+				}
+				if (EditorCategoryButtonColor_Profile_replace)
+				{
+					__instance.colorFilterProfile = EditorCategoryButtonColor_Profile_color;
+				}
+				if (EditorCategoryButtonColor_Subassembly_replace)
+				{
+					__instance.colorSubassembly = EditorCategoryButtonColor_Subassembly_color;
+				}
+				if (EditorCategoryButtonColor_Variants_replace)
+				{
+					__instance.colorVariants = EditorCategoryButtonColor_Variants_color;
+				}
+				if (EditorCategoryButtonColor_Custom_replace)
+				{
+					__instance.colorCategory = EditorCategoryButtonColor_Custom_color;
+				}
+			}
+		}
 		/*
 		Perhaps at some point we might tackle orbital lines
 		

--- a/README.md
+++ b/README.md
@@ -78,7 +78,16 @@ HUDReplacerRecolor:NEEDS[HUDReplacer]
 	SASDisplayOnColor = 1,1,1,1
 	SASDisplayOffColor = 1,1,1,1
 	RCSDisplayOnColor = 1,1,1,1
-	RCSDisplayOffColor = 1,1,1,1
+	RCSDisplayOffColor = 1,1,1,1	
+	EditorCategoryButtonColor = 1,1,1,1
+	EditorCategoryModuleButtonColor = 1,1,1,1
+	EditorCategoryResourceButtonColor = 1,1,1,1
+	EditorCategoryManufacturerButtonColor = 1,1,1,1
+	EditorCategoryTechButtonColor = 1,1,1,1
+	EditorCategoryProfileButtonColor = 1,1,1,1
+	EditorCategorySubassemblyButtonColor = 1,1,1,1
+	EditorCategoryVariantsButtonColor = 1,1,1,1
+	EditorCategoryCustomButtonColor = 1,1,1,1
 }
 ```
 


### PR DESCRIPTION
Addressess [this comment](https://forum.kerbalspaceprogram.com/topic/216056-wip-112x-hudreplacer-v1211-beta/?do=findComment&comment=4357216) (editor category buttons can now be a monochrome color without a blue tint) and also allows recolor support for the advanced editor category buttons. 
![image](https://github.com/user-attachments/assets/06adb016-ab84-4787-9e6c-844571eea856)
<details>
	<summary>sidenote: </summary>
	There's probably a cleaner way to do this but it works and I'm too tired.
</details>
