### PR TITLE
Allow other scripts to add configs at runtime

### DIFF
--- a/HarmonyPatches.cs
+++ b/HarmonyPatches.cs
@@ -237,7 +237,7 @@ namespace HUDReplacer
 					}
 				}
 				Texture2D[] tex_array = textures.ToArray();
-				if (tex_array.Length > 0) HUDReplacer.instance.ReplaceTextures(tex_array);
+				if (tex_array.Length > 0) HUDReplacer.Instance.ReplaceTextures(tex_array);
 			}
 		}
 


### PR DESCRIPTION
Allows other scripts to add HUDReplacer configs at runtime by:
1. Adding a ConfigNode to `additionalConfigNodes` or `additionalRecolorNodes`
2. Calling GetTextures and ReplaceTextures (if replacing textures) or LoadHUDColors (if recoloring)